### PR TITLE
Update python-finds dependency to version 3.1.*

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
     author='Henryk Plötz',
     author_email='henryk@ploetzli.ch',
     license='Apache Software License',
-    install_requires=['fints==3.0.*', 'schwifty', 'fints-url', 'django-securebox'],
+    install_requires=['fints==3.1.*', 'schwifty', 'fints-url', 'django-securebox'],
     packages=find_packages(exclude=['tests', 'tests.*']),
     include_package_data=True,
     cmdclass=cmdclass,


### PR DESCRIPTION
PR to set the dependency requirement of python-fints to newer version to avoid error on setup mentioned in #2 
